### PR TITLE
Optimize updatedb command

### DIFF
--- a/DD role updater/RoleUpdater.cs
+++ b/DD role updater/RoleUpdater.cs
@@ -53,15 +53,15 @@ namespace Clubber.DdRoleUpdater
 			foreach (DdUser user in db.Values)
 				tasks.Add(UpdateUserRoles(user));
 
-			bool updatedAnyUsers = (await Task.WhenAll(tasks)).Any();
-			if (updatedAnyUsers)
+			int usersUpdated = (await Task.WhenAll(tasks)).Count();
+			if (usersUpdated > 0)
 			{
-				await SerializeDbAndReply(db, $"✅ Successfully updated database and member roles.\nExecution took {stopwatch.ElapsedMilliseconds} ms");
+				await SerializeDbAndReply(db, $"✅ Successfully updated database and member roles for {usersUpdated} users.\nExecution took {stopwatch.ElapsedMilliseconds} ms");
 				await msg.DeleteAsync();
 			}
 			else
 			{
-				await msg.ModifyAsync(m => m.Content = "No role updates were needed.\nExecution took {stopwatch.ElapsedMilliseconds} ms");
+				await msg.ModifyAsync(m => m.Content = $"No role updates were needed.\nExecution took {stopwatch.ElapsedMilliseconds} ms");
 			}
 		}
 


### PR DESCRIPTION
- Use early rejection in `UpdateUserRoles` method (don't send a request when the user is not in the server)
- Fetch user time from Hasmodai directly
- Send all requests at once instead of waiting for them one by one