### PR TITLE
Sanitize names, add ChannelClearingService

### DIFF
--- a/Clubber.Domain/BackgroundTasks/ChannelClearingService.cs
+++ b/Clubber.Domain/BackgroundTasks/ChannelClearingService.cs
@@ -1,0 +1,36 @@
+﻿using Clubber.Domain.Helpers;
+using Discord;
+using Discord.WebSocket;
+using Microsoft.Extensions.Configuration;
+
+namespace Clubber.Domain.BackgroundTasks;
+
+public class ChannelClearingService : AbstractBackgroundService
+{
+	private readonly IConfiguration _config;
+	private readonly IDiscordHelper _discordHelper;
+
+	public ChannelClearingService(IConfiguration config, IDiscordHelper discordHelper)
+	{
+		_config = config;
+		_discordHelper = discordHelper;
+	}
+
+	protected override TimeSpan Interval => TimeSpan.FromDays(1);
+
+	private static readonly TimeSpan _inactivityTime = TimeSpan.FromDays(1);
+
+	protected override async Task ExecuteTaskAsync(CancellationToken stoppingToken)
+	{
+		ulong registerChannelId = _config.GetValue<ulong>("RegisterChannelId");
+		SocketTextChannel registerChannel = _discordHelper.GetTextChannel(registerChannelId);
+
+		IOrderedEnumerable<IMessage> messages = (await registerChannel.GetMessagesAsync(1).FlattenAsync()).OrderBy(x => x.Timestamp);
+
+		// Only clear if there has been no activity for
+		if (messages.FirstOrDefault() is { } msg && DateTimeOffset.Now - msg.Timestamp >= _inactivityTime)
+		{
+			await _discordHelper.ClearChannelAsync(registerChannel);
+		}
+	}
+}

--- a/Clubber.Domain/Clubber.Domain.csproj
+++ b/Clubber.Domain/Clubber.Domain.csproj
@@ -10,16 +10,16 @@
 
   <ItemGroup>
     <PackageReference Include="Discord.Net" Version="3.13.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
-    <PackageReference Include="SixLabors.Fonts" Version="2.0.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+    <PackageReference Include="SixLabors.Fonts" Version="2.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.2" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Clubber.Domain/Extensions/ExtensionMethods.cs
+++ b/Clubber.Domain/Extensions/ExtensionMethods.cs
@@ -39,14 +39,17 @@ public static class ExtensionMethods
 		return count;
 	}
 
+	/// <summary>
+	/// Returns a sanitized string representing the name of the user in the order Nickname > GlobalName > Username.
+	/// </summary>
 	[return: NotNullIfNotNull(nameof(guildUser))]
-	public static string? AvailableName(this IGuildUser? guildUser)
+	public static string? AvailableNameSanitized(this IGuildUser? guildUser)
 	{
 		if (guildUser is null)
 		{
 			return null;
 		}
 
-		return guildUser.Nickname ?? guildUser.GlobalName ?? guildUser.Username;
+		return Format.Sanitize(guildUser.Nickname ?? guildUser.GlobalName ?? guildUser.Username);
 	}
 }

--- a/Clubber.Domain/Helpers/DatabaseHelper.cs
+++ b/Clubber.Domain/Helpers/DatabaseHelper.cs
@@ -30,7 +30,7 @@ public class DatabaseHelper : IDatabaseHelper
 	{
 		try
 		{
-			uint[] playerRequest = { lbId };
+			uint[] playerRequest = [lbId];
 
 			EntryResponse lbPlayer = (await _webService.GetLbPlayers(playerRequest))[0];
 			DdUser newDdUser = new(user.Id, lbPlayer.Id);

--- a/Clubber.Domain/Helpers/DiscordHelper.cs
+++ b/Clubber.Domain/Helpers/DiscordHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Clubber.Domain.Models.Exceptions;
+using Discord;
 using Discord.WebSocket;
 
 namespace Clubber.Domain.Helpers;
@@ -20,4 +21,13 @@ public class DiscordHelper : IDiscordHelper
 
 	public SocketGuild? GetGuild(ulong guildId)
 		=> _client.GetGuild(guildId);
+
+	public async Task ClearChannelAsync(ITextChannel channel)
+	{
+		DateTimeOffset utcNow = DateTimeOffset.UtcNow;
+		IEnumerable<IMessage> lastHundredMessages = await channel.GetMessagesAsync().FlattenAsync();
+		IEnumerable<IMessage> messagesToDelete = lastHundredMessages.Where(x => (utcNow - x.Timestamp).TotalDays <= 14 && x.Flags is not MessageFlags.Ephemeral);
+
+		await channel.DeleteMessagesAsync(messagesToDelete);
+	}
 }

--- a/Clubber.Domain/Helpers/EmbedHelper.cs
+++ b/Clubber.Domain/Helpers/EmbedHelper.cs
@@ -35,7 +35,7 @@ public static class EmbedHelper
 	public static Embed UpdateRoles(UpdateRolesResponse.Full response)
 	{
 		EmbedBuilder embed = new EmbedBuilder()
-			.WithTitle($"Updated roles for {response.User.AvailableName()}")
+			.WithTitle($"Updated roles for {response.User.AvailableNameSanitized()}")
 			.WithDescription($"User: {response.User.Mention}")
 			.WithThumbnailUrl(response.User.GetDisplayAvatarUrl() ?? response.User.GetDefaultAvatarUrl());
 
@@ -65,13 +65,14 @@ public static class EmbedHelper
 	{
 		DateTime? playerPbDatetime = playerHistory?.ScoreHistory.LastOrDefault()?.DateTime;
 		string? pbDateTimeFormatted = playerPbDatetime is null ? null : $"\n📅 Achieved on: {playerPbDatetime:yyyy-MM-dd}";
+		string sanitizedLbName = Format.Sanitize(lbPlayer.Username);
 
 		return new EmbedBuilder()
-			.WithTitle($"Stats for {guildUser?.AvailableName() ?? lbPlayer.Username}")
+			.WithTitle($"Stats for {guildUser?.AvailableNameSanitized() ?? sanitizedLbName}")
 			.WithThumbnailUrl(guildUser?.GetDisplayAvatarUrl() ?? guildUser?.GetDefaultAvatarUrl() ?? string.Empty)
 			.WithDescription(
 				$"""
-				✏️ Leaderboard name: {lbPlayer.Username}
+				✏️ Leaderboard name: {sanitizedLbName}
 				🛂 Leaderboard ID: {lbPlayer.Id}
 				⏲️ Score: {lbPlayer.Time / 10000d:0.0000}s {pbDateTimeFormatted}
 				🥇 Rank: {lbPlayer.Rank}
@@ -81,7 +82,7 @@ public static class EmbedHelper
 
 				• For full stats, use `statsf`.
 
-				{Format.Url($"{lbPlayer.Username} on devildaggers.info", $"https://devildaggers.info/leaderboard/player/{lbPlayer.Id}")}
+				{Format.Url($"{sanitizedLbName} on devildaggers.info", $"https://devildaggers.info/leaderboard/player/{lbPlayer.Id}")}
 				""")
 			.Build();
 	}
@@ -94,13 +95,14 @@ public static class EmbedHelper
 		GetPlayerHistoryScoreEntry? playerPb = playerHistory?.ScoreHistory.LastOrDefault();
 		string? peakRankFormatted = playerHistory?.BestRank is null ? null : $"(Best: {playerHistory.BestRank})";
 		TimeSpan ts = TimeSpan.FromSeconds((double)lbPlayer.TimeTotal / 10000);
+		string sanitizedLbName = Format.Sanitize(lbPlayer.Username);
 
 		EmbedBuilder embedBuilder = new EmbedBuilder()
-			.WithTitle($"Stats for {guildUser.AvailableName() ?? lbPlayer.Username}")
+			.WithTitle($"Stats for {guildUser?.AvailableNameSanitized() ?? sanitizedLbName}")
 			.WithThumbnailUrl(guildUser?.GetDisplayAvatarUrl() ?? guildUser?.GetDefaultAvatarUrl() ?? string.Empty)
 			.WithDescription(
 				$"""
-				✏️ Leaderboard name: {lbPlayer.Username}
+				✏️ Leaderboard name: {sanitizedLbName}
 				🛂 Leaderboard ID: {lbPlayer.Id}
 				⏲️ Score: {lbPlayer.Time / 10000d:0.0000}s
 				🥇 Rank: {lbPlayer.Rank} {peakRankFormatted}
@@ -135,7 +137,7 @@ public static class EmbedHelper
 			embedBuilder.AddField("💤 Last active", $"{lastActivity.DateTime:yyyy-MM-dd}", true);
 		}
 
-		embedBuilder.AddField("\u200B", Format.Url($"{lbPlayer.Username} on devildaggers.info", $"https://devildaggers.info/leaderboard/player/{lbPlayer.Id}"));
+		embedBuilder.AddField("\u200B", Format.Url($"{sanitizedLbName} on devildaggers.info", $"https://devildaggers.info/leaderboard/player/{lbPlayer.Id}"));
 
 		return embedBuilder.Build();
 	}
@@ -224,10 +226,8 @@ public static class EmbedHelper
 
 	private static string FormatUser(IGuildUser user)
 	{
-		if (user.Nickname is null)
-			return user.Username;
-
-		return $"{user.Username} ({user.Nickname})";
+		string formattedName = user.Nickname is null ? user.Username : $"{user.Username} ({user.Nickname})";
+		return Format.Sanitize(formattedName);
 	}
 
 	public static Embed[] RegisterEmbeds(IUser botUser)
@@ -372,7 +372,7 @@ public static class EmbedHelper
 		for (int i = 0; i < currentTopPeakRuns.Length; i++)
 		{
 			HomingPeakRun currentPeakRun = currentTopPeakRuns[i];
-			sb.Append($"\n{i + 1}. [{currentPeakRun.HomingPeak}]({currentPeakRun.Source}) {currentPeakRun.PlayerName}");
+			sb.Append($"\n{i + 1}. [{currentPeakRun.HomingPeak}]({currentPeakRun.Source}) {Format.Sanitize(currentPeakRun.PlayerName)}");
 		}
 
 		return new EmbedBuilder()

--- a/Clubber.Domain/Helpers/IDiscordHelper.cs
+++ b/Clubber.Domain/Helpers/IDiscordHelper.cs
@@ -1,4 +1,5 @@
-﻿using Discord.WebSocket;
+﻿using Discord;
+using Discord.WebSocket;
 
 namespace Clubber.Domain.Helpers;
 
@@ -9,4 +10,6 @@ public interface IDiscordHelper
 	SocketGuildUser? GetGuildUser(ulong guildId, ulong userId);
 
 	SocketGuild? GetGuild(ulong guildId);
+
+	Task ClearChannelAsync(ITextChannel channel);
 }

--- a/Clubber.Domain/Helpers/LeaderboardImageGenerator.cs
+++ b/Clubber.Domain/Helpers/LeaderboardImageGenerator.cs
@@ -1,6 +1,9 @@
 using Clubber.Domain.Extensions;
 using SixLabors.Fonts;
+using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
 
 namespace Clubber.Domain.Helpers;
 

--- a/Clubber.Domain/Models/DdSplits/Split.cs
+++ b/Clubber.Domain/Models/DdSplits/Split.cs
@@ -17,8 +17,8 @@ public class Split
 	public int Value { get; set; }
 
 	[JsonIgnore]
-	public static (string Name, int Time)[] V3Splits => new[]
-	{
+	public static (string Name, int Time)[] V3Splits =>
+	[
 		("350", 366),
 		("700", 709),
 		("800", 800),
@@ -33,5 +33,5 @@ public class Split
 		("1230", 1231),
 		("1260", 1260),
 		("1290", 1290),
-	};
+	];
 }

--- a/Clubber.Domain/Modules/Moderator.cs
+++ b/Clubber.Domain/Modules/Moderator.cs
@@ -71,18 +71,12 @@ public class Moderator : ExtendedModulebase<SocketCommandContext>
 	public async Task Clear()
 	{
 		ulong registerChannelId = _config.GetValue<ulong>("RegisterChannelId");
-		if (Context.Channel is not SocketTextChannel currentTextChannel || currentTextChannel.Id != registerChannelId)
+		if (Context.Channel is not SocketTextChannel channel || channel.Id != registerChannelId)
 		{
 			await ReplyAsync($"This command can only be run in <#{registerChannelId}>.");
 			return;
 		}
 
-		DateTimeOffset utcNow = DateTimeOffset.Now;
-		IEnumerable<IMessage> lastHundredMessages = await currentTextChannel.GetMessagesAsync().FlattenAsync();
-		IEnumerable<IMessage> messagesToDelete = lastHundredMessages
-			.Where(x => (utcNow - x.Timestamp).TotalDays <= 14)
-			.OrderByDescending(m => m.CreatedAt);
-
-		await currentTextChannel.DeleteMessagesAsync(messagesToDelete);
+		await _discordHelper.ClearChannelAsync(channel);
 	}
 }

--- a/Clubber.Domain/Modules/Moderator.cs
+++ b/Clubber.Domain/Modules/Moderator.cs
@@ -77,12 +77,11 @@ public class Moderator : ExtendedModulebase<SocketCommandContext>
 			return;
 		}
 
-		const int messagesToSkip = 1;
+		DateTimeOffset utcNow = DateTimeOffset.Now;
 		IEnumerable<IMessage> lastHundredMessages = await currentTextChannel.GetMessagesAsync().FlattenAsync();
 		IEnumerable<IMessage> messagesToDelete = lastHundredMessages
-			.Where(x => (DateTimeOffset.UtcNow - x.Timestamp).TotalDays <= 14)
-			.OrderByDescending(m => m.CreatedAt)
-			.SkipLast(messagesToSkip);
+			.Where(x => (utcNow - x.Timestamp).TotalDays <= 14)
+			.OrderByDescending(m => m.CreatedAt);
 
 		await currentTextChannel.DeleteMessagesAsync(messagesToDelete);
 	}

--- a/Clubber.Domain/Modules/PeakHomingModule.cs
+++ b/Clubber.Domain/Modules/PeakHomingModule.cs
@@ -69,7 +69,7 @@ public class PeakhomingModule : ExtendedModulebase<SocketCommandContext>
 		DdUser? ding = await _databaseHelper.GetDdUserBy(ddStatsRun.GameInfo.PlayerId);
 		if (ding != null && Context.Guild.GetUser(ding.DiscordId) is { } user)
 		{
-			userName = user.AvailableName();
+			userName = user.AvailableNameSanitized();
 			avatarUrl = user.GetDisplayAvatarUrl() ?? user.GetDefaultAvatarUrl();
 		}
 

--- a/Clubber.Domain/Modules/SplitsModule.cs
+++ b/Clubber.Domain/Modules/SplitsModule.cs
@@ -58,7 +58,7 @@ public class SplitsModule : ExtendedModulebase<SocketCommandContext>
 			return;
 
 		string desc = description ?? $"{ddstatsRun.GameInfo.PlayerName} {ddstatsRun.GameInfo.GameTime:0.0000}";
-		(BestSplit[] OldBestSplits, BestSplit[] UpdatedBestSplits) response = await _databaseHelper.UpdateBestSplitsIfNeeded(new[] { split }, ddstatsRun, desc);
+		(BestSplit[] OldBestSplits, BestSplit[] UpdatedBestSplits) response = await _databaseHelper.UpdateBestSplitsIfNeeded([split], ddstatsRun, desc);
 		if (response.UpdatedBestSplits.Length == 0)
 		{
 			await InlineReplyAsync("No updates were needed.");

--- a/Clubber.Domain/Services/UserService.cs
+++ b/Clubber.Domain/Services/UserService.cs
@@ -1,3 +1,4 @@
+using Clubber.Domain.Extensions;
 using Clubber.Domain.Helpers;
 using Clubber.Domain.Models;
 using Clubber.Domain.Models.Exceptions;
@@ -27,7 +28,7 @@ public class UserService
 
 		if (await _databaseHelper.GetDdUserBy(guildUser.Id) is not null)
 		{
-			return Result.Failure($"User `{guildUser.Username}` is already registered.");
+			return Result.Failure($"User `{guildUser.AvailableNameSanitized()}` is already registered.");
 		}
 
 		return Result.Success();
@@ -48,7 +49,7 @@ public class UserService
 
 		if (guildUser.GuildPermissions.ManageRoles)
 		{
-			return Result.Failure($"`{guildUser.Username}` is not registered.");
+			return Result.Failure($"`{guildUser.AvailableNameSanitized()}` is not registered.");
 		}
 
 		ulong unregRoleId = _config.GetValue<ulong>("UnregisteredRoleId");
@@ -56,8 +57,8 @@ public class UserService
 
 		string roleAssignerRoleId = _config["RoleAssignerRoleId"] ?? throw new ConfigurationMissingException("RoleAssignerRoleId");
 		string message = userUsedCommandForThemselves
-			? $"You're not registered, {guildUser.Username}. Only a <@&{roleAssignerRoleId}> can register you."
-			: $"`{guildUser.Username}` is not registered. Only a <@&{roleAssignerRoleId}> can register them.";
+			? $"You're not registered, {guildUser.AvailableNameSanitized()}. Only a <@&{roleAssignerRoleId}> can register you."
+			: $"`{guildUser.AvailableNameSanitized()}` is not registered. Only a <@&{roleAssignerRoleId}> can register them.";
 
 		string registerChannelId = _config["RegisterChannelId"] ?? throw new ConfigurationMissingException("RegisterChannelId");
 		if (userHasUnregRole)
@@ -82,8 +83,8 @@ public class UserService
 		}
 
 		string message = userUsedCommandForThemselves
-			? $"{guildUser.Username}, you can't register because you've cheated."
-			: $"{guildUser.Username} can't be registered because they've cheated.";
+			? $"{guildUser.AvailableNameSanitized()}, you can't register because you've cheated."
+			: $"{guildUser.AvailableNameSanitized()} can't be registered because they've cheated.";
 
 		return Result.Failure(message);
 	}

--- a/Clubber.UnitTests/Clubber.UnitTests.csproj
+++ b/Clubber.UnitTests/Clubber.UnitTests.csproj
@@ -14,8 +14,8 @@
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="Moq" Version="4.20.69" />
-        <PackageReference Include="xunit" Version="2.6.2" />
+        <PackageReference Include="Moq" Version="4.20.70" />
+        <PackageReference Include="xunit" Version="2.6.6" />
         <PackageReference Include="coverlet.collector" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/Clubber.Web.Client/Clubber.Web.Client.csproj
+++ b/Clubber.Web.Client/Clubber.Web.Client.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.1" />
   </ItemGroup>
 
 </Project>

--- a/Clubber.Web.Server/Clubber.Web.Server.csproj
+++ b/Clubber.Web.Server/Clubber.Web.Server.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />

--- a/Clubber.Web.Server/Program.cs
+++ b/Clubber.Web.Server/Program.cs
@@ -76,6 +76,7 @@ internal static class Program
 			builder.Services.AddHostedService<DdNewsPostService>();
 			builder.Services.AddHostedService<DatabaseUpdateService>();
 			builder.Services.AddHostedService<KeepAppAliveService>();
+			builder.Services.AddHostedService<ChannelClearingService>();
 		}
 
 		builder.Services.AddSwaggerGen(options =>

--- a/Clubber.Web.Server/Program.cs
+++ b/Clubber.Web.Server/Program.cs
@@ -23,7 +23,7 @@ internal static class Program
 	{
 		CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
 #pragma warning disable CS0618 // Type or member is obsolete
-		NpgsqlConnection.GlobalTypeMapper.EnableDynamicJson(new []{ typeof(EntryResponse), typeof(GameInfo) });
+		NpgsqlConnection.GlobalTypeMapper.EnableDynamicJson([typeof(EntryResponse), typeof(GameInfo)]);
 #pragma warning restore CS0618 // Type or member is obsolete
 
 		WebApplicationBuilder builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION
### Sanitize names, add ChannelClearingService

- Sanitize strings in all (most) instances where usernames are used
- Fix channel clearing process skipping one message
- Clear channel periodically if inactive for long enough (1 day)
- Update packages and fix usings (ImageSharp breaking change)